### PR TITLE
Use DocFileSuite to test the readme's example

### DIFF
--- a/makefile
+++ b/makefile
@@ -25,7 +25,6 @@ lint:
 test:
 	python -m coverage run -m $(SRCS).tests
 	python -m coverage report
-	python -m doctest README.md
 
 html: .venv README.md docs/*.rst docs/conf.py
 	source .venv/bin/activate && sphinx-build -b html docs html

--- a/stdlibs/tests/__init__.py
+++ b/stdlibs/tests/__init__.py
@@ -1,6 +1,7 @@
 # Copyright 2022 Amethyst Reese
 # Licensed under the MIT license
 
+import doctest
 import os
 import sys
 from pathlib import Path
@@ -51,12 +52,7 @@ class StdlibsTest(TestCase):
             stdlibs.stdlib_module_names("all"),
         )
 
-    def test_readme_example(self) -> None:
-        self.assertEqual(
-            ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"],
-            [
-                v
-                for v in stdlibs.KNOWN_VERSIONS
-                if "dataclasses" in stdlibs.stdlib_module_names(v)
-            ],
-        )
+
+def load_tests(loader, tests, ignore):
+    tests.addTests(doctest.DocFileSuite("../../README.md"))
+    return tests

--- a/stdlibs/tests/__init__.py
+++ b/stdlibs/tests/__init__.py
@@ -5,7 +5,7 @@ import doctest
 import os
 import sys
 from pathlib import Path
-from unittest import mock, skipIf, TestCase
+from unittest import mock, skipIf, TestCase, TestLoader, TestSuite
 
 import stdlibs
 
@@ -53,6 +53,6 @@ class StdlibsTest(TestCase):
         )
 
 
-def load_tests(loader, tests, ignore):
+def load_tests(loader: TestLoader, tests: TestSuite, _pattern: None) -> TestSuite:
     tests.addTests(doctest.DocFileSuite("../../README.md"))
     return tests


### PR DESCRIPTION
I'm updating my skel to include this on new projects, and figured it's worth proposing to see if you like it.

Pros:

* Doctests automatically count towards coverage now (but we're already at 100%)
* Don't need to duplicate the example in `test_readme_example` for people who aren't using `make`
* Easier to remember to run them
* Easier to integrate with other build tools, like tpx or things that consume junit.xml
 
Cons:

* The test names are informative, but hurt my eyes

The integration was in the docs the whole time, I finally went looking for how: [doctest#unittest-api](https://docs.python.org/3/library/doctest.html#unittest-api)