### PR TITLE
Add missing dependency on libcst

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,9 @@ classifiers = [
     "Typing :: Typed",
 ]
 requires-python = ">=3.8"
-dependencies = []
+dependencies = [
+    "libcst~=1.0",
+]
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
This is used in stdlibs/fetch.py but never declared as a dependency