### PR TITLE
Correct 3.9's `_peg_parser` name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ superset of top-level names you may have, and a superset of those in
 >>> from stdlibs import module_names
 >>> print("os" in module_names)
 True
->>> print("peg_parser" in module_names)  # 3.9+
+>>> print("zoneinfo" in module_names)  # 3.9+
 True
 
 ```
@@ -53,7 +53,7 @@ If you need a specific version, those are available as other modules:
 >>> from stdlibs.py36 import module_names as module_names_py36
 >>> print("os" in module_names_py36)
 True
->>> print("peg_parser" in module_names_py36)
+>>> print("zoneinfo" in module_names_py36)
 False
 
 ```

--- a/stdlibs/fetch.py
+++ b/stdlibs/fetch.py
@@ -217,6 +217,7 @@ def regen(version: str) -> Set[str]:
 
                 if (
                     (s == '"decimal"' and p.name == "_decimal.c")
+                    or (s == '"peg_parser"' and p.name == "_peg_parser.c")
                     or (s == '"_fuzz"' and p.name == "_xxtestfuzz.c")
                     or p.name == "_testmultiphase.c"
                 ):

--- a/stdlibs/py.py
+++ b/stdlibs/py.py
@@ -454,7 +454,6 @@ module_names: FrozenSet[str] = frozenset(
         "pathlib",
         "pcre",
         "pdb",
-        "peg_parser",
         "pickle",
         "pickletools",
         "pimp",

--- a/stdlibs/py3.py
+++ b/stdlibs/py3.py
@@ -278,7 +278,6 @@ module_names: FrozenSet[str] = frozenset(
         "pathlib",
         "pcre",
         "pdb",
-        "peg_parser",
         "pickle",
         "pickletools",
         "pipes",

--- a/stdlibs/py39.py
+++ b/stdlibs/py39.py
@@ -224,7 +224,6 @@ module_names: FrozenSet[str] = frozenset(
         "parser",
         "pathlib",
         "pdb",
-        "peg_parser",
         "pickle",
         "pickletools",
         "pipes",


### PR DESCRIPTION
This one declares the wrong `.m_name`, verified on an install of 3.9.

I don't know how I picked this to be in the readme!